### PR TITLE
feat(deposco_client): Add support for inventory reservation

### DIFF
--- a/lib/huginn_deposco_inventory_agent/deposco_client.rb
+++ b/lib/huginn_deposco_inventory_agent/deposco_client.rb
@@ -2,6 +2,11 @@ class DeposcoClient
     @faraday
     @auth
 
+    @headers = {
+      'Accept' => 'application/json',
+      'Content-Type' => 'application/json'
+    }
+
     def initialize(faraday, auth)
         @faraday = faraday
         @auth = auth
@@ -13,8 +18,7 @@ class DeposcoClient
     def get_deposco_stock(sku, business_unit)
         path = "/ctrl/getRestfulATP?businessUnit=#{business_unit}&itemNumber=#{sku}"
         url = "http://#{@auth['site_prefix']}.deposco.com/integration/#{@auth['site_code'] + path}"
-        header = { 'Accept' => 'application/json' }
-        response = @faraday.get(url, nil, header)
+        response = @faraday.get(url, nil, @headers)
         if response.status == 200
             response = response.body
             response = JSON.parse(response)
@@ -25,6 +29,40 @@ class DeposcoClient
                 quantity: response[0]["totalAvailableToPromise"].to_i,
             }
             return result
+        else
+            raise DeposcoAgentError.new(response.body, response.status)
+        end
+    end
+
+    # Make a POST call to the reserve inventory endpoint
+    def reserve_deposco_stock( company, adjustments )
+
+        body = {
+          company: company,
+          adjustments: adjustments
+        }
+
+        url = "https://#{@auth['site_prefix']}.deposco.com/integration/#{@auth['site_code']}/ctrl/reserveInventoryAPI"
+
+        # NOTE:  By default, Faraday sends POST requests with a content type of `application/x-www-form-urlencoded`
+        # In order to send JSON, we need to explicitly convert the hash.
+        response = @faraday.post(url, body.to_json, @headers)
+
+        if response.status == 200
+            data = JSON.parse(response.body)
+
+            if (data['status'] == 'SUCCESS')
+              return data
+            else
+              #  NOTE:  The Reserve Inventory endpoint from Deposco returns some misleading
+              #  status codes at times. For example, if they payload is incorrect, the endpoint
+              #  returns a status of 200 with a message of "porcessed with no response" when we
+              #  would expect something like a 422.
+              #  A response from this endpoint is only truly successful if the _status_ on the
+              #  response body is "SUCCESS"
+
+              raise DeposcoAgentError.new(data, response.status != 200 ? response.status : 500)
+            end
         else
             raise DeposcoAgentError.new(response.body, response.status)
         end

--- a/lib/huginn_deposco_inventory_agent/deposco_inventory_agent.rb
+++ b/lib/huginn_deposco_inventory_agent/deposco_inventory_agent.rb
@@ -10,34 +10,54 @@ module Agents
         default_schedule 'never'
 
         description <<-MD
-        Huginn agent for retrieving sane Deposco quantity data.
+        Huginn agent for retrieving and/or updating inventory data in Deposco
 
-        The deposco api requires you to either get all of the products inventory
-        or to get one at a time. This agent gets one products inventory at a time
-        given a list of skus as an array or a string, rather than pulling all
-        products from deposco every time.
+        This agent provides two key functions (controlled by the) `fetch_inventory`
+        option. When set to `true`, this agent expects to receive an array of SKUs
+        to fetch inventory levels from the Deposco API. These SKUs can be provided
+        as an array, or as a CSV string.
 
-        This agent takes reserved inventory into account and will return the
-        ATP amount specifically (Which is the stock level minus any reserved
-        inventory). It is important that this agent is configured with the proper
-        context (specifically that we should be using a login for the specific
-        client we're trying to pull data for).
+        In this case, the agent will return inventory numbers adjusted by the reserved
+        inventory total. The goal is to provide largely realtime updates to stock levels
+        even in cases where orders from an external eCommerce platform are not immediately
+        imported into Deposco.
 
+        When `fetch_inventory` is set to `false`, this agent expects to receive
+        an array of adjustment objects to be passed to the inventory reservation
+        endpoint.
 
+        Due to how the inventory reservation feature functions (particularly regarding
+        instant inventory), it is important that this agent be configured with
+        contextually appropriate credentials associated with the client for whom inventory
+        is being retrieved.
 
         ### **Options:**
-        *  site_code     - required
-        *  site_prefix   - required
-        *  username      - required
-        *  password      - required
-        *  business_unit - required
-        *  output_mode   - not required ('clean' or 'merge', defaults to 'clean')
-        *  skus          - required (string or array, defaults to string)
+        *  fetch_inventory  - Optional. If provided, it must be either `true` or `false`. Defaults to `true`
+        *  site_code        - Required.
+        *  site_prefix      - Required.
+        *  username         - Required.
+        *  password         - Required.
+        *  business_unit    - Required. This is the code associated with the client for whome you want to fetch/update data
+        *  output_mode      - Optional. If provided, it must be set to either `clean` or `merge`. Defaults to `clean`
+        *  skus             - Required when `fetch_inventory` is `true`. Must be an array or CSV of SKUs.
+        *  adjustments      - An array of adjustment objects to be passed to the inventory reservation endpoint
+
+        **NOTE:** The adustments field should be formatted as follows:
+
+        ```
+        adjustments: [
+          {
+            itemNumber: {sku},
+            value: {adjustment amount}
+          },
+          { ... }
+        ]
+        ```
 
 
         ### **Agent Payloads:**
 
-        **Success Payload:**
+        #### **Fetch Inventory Success Payload:**
 
         ```
         {
@@ -52,7 +72,17 @@ module Agents
         }
         ```
 
-        **Error Payload:**
+        #### **Fetch Inventory Error Payload:**
+
+        **NOTE:** An error payload in this case may not be a catastrophic failure.
+        In most cases, it means that one or more of the products could not be found
+        in Deposco, which may happen for newer products that have been added to the store,
+        but are not yet present in the warehouse.
+
+        The intention of this error payload is to return as much useful data as we can while
+        also notifying users that an error has occurred. It's up to the end user to determine
+        whether this event should terminate the associated scenario execution or if this clan
+        be treated as a partial success.
 
         ```
         {
@@ -71,6 +101,65 @@ module Agents
               ...
             ]
           }
+        }
+        ```
+
+        #### **Reserve Inventory Success Payload:**
+
+        **NOTE:** The `FAILURE` status shown here is somewhat misleading. In some cases,
+        the status on the response _data_ will be a `FAILURE`, but the request itself is
+        still considered a success.
+
+        This will generally happen when a request tries to release more inventory than is
+        currently available. For example, the warehouse has 100 items on hand, but 10 items
+        are currently reserved -- making the _available_ quantity 90 units.
+
+        An adjustment value of -20 would attempt to set the available stock to 110 units (90 - -20),
+        however, since there are only 100 units on hand, this results in an error status with a message
+        such as:
+
+        "Attempted to update item [{SKU}] reserved quantity to a negative value. Reservation set to 0."
+
+        The response.status in this case is still 200.
+
+        ```
+        {
+          ...,
+          reservation_result: {
+            "status": "{SUCCESS | FAILURE}",
+            "requestObj": {
+               "company": "{company name}",
+               "adjustments": [
+                   {
+                       "itemNumber": "{some sku}",
+                       "value": {quantity}
+                   },
+                   { ... }
+               ]
+            },
+            "responseMsg": []
+          }
+          status: 200,
+        }
+
+        #### **Reserve Inventory Error Payload:**
+
+        ```
+        {
+          ...,
+
+          "company": "{company name}",
+          "adjustments": [
+            {
+              "itemNumber": "{some sku}",
+              "value": {quantity}
+            },
+            { ... }
+          ],
+          "error": {
+            message: '{ some error message }'
+          },
+          status: {response status},
         }
         ```
 
@@ -113,12 +202,28 @@ module Agents
               errors.add(:base, "if provided, output_mode must be 'clean' or 'merge'")
             end
 
-            unless options['skus'].present?
-                errors.add(:base, "skus is a required field")
+            if options.has_key?('fetch_inventory') && boolify(options['fetch_inventory']).nil?
+              errors.add(:base, 'when provided, `fetch_inventory` must be either true or false')
             end
 
-            unless (options['skus'].is_a?(Array) || options['skus'].is_a?(String)) && !blank?
-                errors.add(:base, "skus must be an array or a string")
+            if !options.has_key?('fetch_inventory') || boolify(options['fetch_inventory'])
+              if !options['skus'].present?
+                  errors.add(:base, "When `fetch_inventory` mode is enabled, `skus` is a required field")
+              else
+                unless (options['skus'].is_a?(Array) || options['skus'].is_a?(String))
+                    errors.add(:base, "skus must be an array or a string")
+                end
+              end
+            end
+
+            if options.has_key?('fetch_inventory') && !boolify(options['fetch_inventory'])
+              unless options['adjustments'].present?
+                errors.add(:base, "When `fetch_inventory` mode is disabled, `adjustments` is a required field")
+              end
+
+              unless options['adjustments'].is_a?(Array) || options['adjustments'].is_a?(String)
+                  errors.add(:base, "adjustments must be an array of adjustment objects or a string")
+              end
             end
         end
 
@@ -162,24 +267,44 @@ module Agents
 
             client = DeposcoClient.new(faraday, auth)
 
-            # Get deposco stock inventory
-            data = fetch_product_inventory(client, skus, business_unit)
-            deposco_stock = data[:deposco_stock]
-            errors = data[:errors]
-
             new_event = interpolated['output_mode'].to_s == 'merge' ? event.payload.dup : {}
+            fetch_inventory = boolify(options['fetch_inventory']).nil? ? true : boolify(options['fetch_inventory'])
 
-            if errors.blank?
-                create_event payload: new_event.merge(
-                    deposco_stock: deposco_stock,
-                    status: 200
-                )
+            if (fetch_inventory)
+                skus = interpolated(event.payload)[:skus]
+                if skus.is_a?(String)
+                    skus = skus.split(',')
+                end
+
+                # Get deposco stock inventory
+                data = fetch_product_inventory(client, skus, business_unit)
+                deposco_stock = data[:deposco_stock]
+                errors = data[:errors]
+
+                if errors.blank?
+                    create_event payload: new_event.merge(
+                        deposco_stock: deposco_stock,
+                        status: 200
+                    )
+                else
+                    create_event payload: new_event.merge(
+                        deposco_stock: deposco_stock,
+                        status: 500,
+                        errors: errors
+                    )
+                end
             else
-                create_event payload: new_event.merge(
-                    deposco_stock: deposco_stock,
-                    status: 500,
-                    errors: errors
-                )
+                adjustments = interpolated(event.payload)[:adjustments]
+
+                if adjustments.is_a?(Array)
+                    reserve_product_inventory(client, business_unit, adjustments, new_event)
+                else
+                    create_event payload: new_event.merge(
+                      adjustments: adjustments,
+                      status: 500,
+                      error: 'The interpolated `adjustments` field must be an array. If you are passing a key from an incoming payload, consider using `{key | as_object}`'
+                    )
+                end
             end
         end
 
@@ -198,7 +323,7 @@ module Agents
                     item = deposco_client.get_deposco_stock(sku, business_unit)
 
                     if item.is_a?(Hash)
-                        deposco_stock.push(item)
+                        deposco_stock << (item)
                     else
                         errors.push({
                             'sku': sku,
@@ -211,6 +336,7 @@ module Agents
                     if defined?(e.response_status)
                         status = e.response_status
                     end
+
                     errors.push({
                         'sku': sku,
                         'status_code': status,
@@ -235,6 +361,43 @@ module Agents
                 deposco_stock: deposco_stock,
                 errors: errors
             }
+        end
+
+        # Attempts to update the inventory reservation numbers with the provided `adjustments`
+        # NOTE: passing an adjustment with a positive number will _reserve_ inventory,
+        # while passing a negative number will _release_ inventory.
+        def reserve_product_inventory(deposco_client, business_unit, adjustments, event)
+            begin
+              result = deposco_client.reserve_deposco_stock(business_unit, adjustments)
+
+              create_event payload: event.merge(
+                  status: 200,
+                  rservation_result: result,
+              )
+            rescue Faraday::Error::ClientError => e
+                status = 500
+                if defined?(e.response_status)
+                    status = e.response_status
+                end
+
+                create_event payload: event.merge(
+                    adjustments: adjustments,
+                    status: status,
+                    error: e.message
+                )
+            rescue DeposcoAgentError => e
+              create_event payload: event.merge(
+                  adjustments: adjustments,
+                  status: e.status_code,
+                  error: e.message
+              )
+            rescue => e
+              create_event payload: event.merge(
+                  adjustments: adjustments,
+                  status: 500,
+                  error: e.message
+              )
+            end
         end
     end
 end


### PR DESCRIPTION
Add a secondary function to the deposco inventory agent that can be
configured to reserve deposco inventory for products instead of just
fetching current numbers

https://trello.com/c/by8t35r8/711-asbat-see-bigcommerce-orders-reserve-inventory-in-deposco